### PR TITLE
Updated to webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
     on_failure: change
 
 node_js:
-  - '5.11'
+  - '6.14.3'
 
 before_install:
   - export CHROME_BIN=chromium-browser

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-Webpack 2 + TypeScript starter
----
+Webpack 4 + TypeScript starter
+------------------------------
 
 [![Build Status](https://travis-ci.org/juristr/webpack-typescript-starter.svg?branch=master)](https://travis-ci.org/juristr/webpack-typescript-starter)
 
-This is by far no sophisticated starter or whatever. The goal is to get the simplest possible setup to get you started with Webpack 2 and TypeScript. You can then start from here and add further stuff you need, such as SASS compilation, add framework specific stuff etc.
+This is by far no sophisticated starter or whatever. The goal is to get the simplest possible setup to get you started with Webpack 4 and TypeScript. You can then start from here and add further stuff you need, such as SASS compilation, add framework specific stuff etc.
 
-Also check out the official Webpack 2 docs for a proper TypeScript setup: https://webpack.js.org/guides/webpack-and-typescript/
+Also check out the official Webpack 4 docs for a proper TypeScript setup: https://webpack.js.org/guides/typescript/
 
 _Note, this is still a WIP. Contributions/suggestions are welcome :smiley:_
 
 ## Features
 
-- [x] Webpack 2
+- [x] Webpack 4
 - [x] TypeScript 2 compilation
 - [x] ts-lint
-- [x] Webpack 2 Development Server
+- [x] Webpack Development Server
 - [x] Karma and Jasmine test execution
 
 ## How to use

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,3 +1,5 @@
+const webpackConfig = require('./webpack.config.js');
+webpackConfig.mode = 'production';
 
 module.exports = function(config) {
   config.set({
@@ -19,7 +21,7 @@ module.exports = function(config) {
       'spec.bundle.js': ['webpack']
     },
 
-    webpack: require('./webpack-test.config'),
+    webpack: webpackConfig,
 
     webpackMiddleware: {
       stats: 'errors-only'

--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
   "name": "webpack-typescript-starter",
   "version": "0.0.1",
-  "description": "A simple Webpack 2 starter with TypeScript transpilation",
+  "description": "A simple Webpack 4 starter with TypeScript transpilation",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --port 9000 --inline --progress --profile --colors --watch --content-base src/",
-    "build": "webpack --config webpack.config.js",
+    "start": "webpack-dev-server --port 9000 --inline --progress --profile --colors --watch --content-base src/ --mode development",
+    "build": "webpack --config webpack.config.js --mode production",
     "build.prod": "webpack --config webpack.config.js -p",
     "test": "karma start karma.config.js"
   },
   "keywords": [
     "webpack",
-    "webpack2",
+    "webpack4",
     "typescript"
   ],
   "author": "Juri Strumpflohner",
   "license": "ISC",
   "devDependencies": {
-    "@types/jasmine": "2.5.40",
+    "@types/jasmine": "2.8.7",
     "@types/node": "7.0.0",
-    "awesome-typescript-loader": "3.0.0-beta.18",
-    "jasmine-core": "2.5.2",
-    "karma": "1.4.0",
-    "karma-jasmine": "1.1.0",
-    "karma-phantomjs-launcher": "1.0.2",
-    "karma-webpack": "2.0.1",
-    "source-map-loader": "0.1.6",
-    "tslint": "4.3.1",
-    "tslint-loader": "3.3.0",
-    "typescript": "2.1.5",
-    "webpack": "2.2.1",
-    "webpack-dev-server": "2.2.1"
+    "awesome-typescript-loader": "5.2.0",
+    "jasmine-core": "3.1.0",
+    "karma": "2.0.4",
+    "karma-jasmine": "1.1.2",
+    "karma-phantomjs-launcher": "1.0.4",
+    "karma-webpack": "3.0.0",
+    "source-map-loader": "0.2.3",
+    "tslint": "5.10.0",
+    "tslint-loader": "3.6.0",
+    "typescript": "2.8.3",
+    "webpack": "4.12.0",
+    "webpack-cli": "3.0.8",
+    "webpack-dev-server": "3.1.4"
   }
 }
-


### PR DESCRIPTION
Hi @juristr!

I have updated the starter to webpack 4. Also updated all other dependencies to the latest available version.

Some remarks:
* The webpack CLI moved into a separate package: webpack-cli
* `mode` configuration is mandatory for webpack 4. Not setting the mode results in a warning and fallback to `production` mode. See https://webpack.js.org/concepts/mode/