### PR TITLE
enable es-next and typescript in build (dist)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [
+        "@babel/env",
+        "@babel/typescript"
+    ],
+    "plugins": [
+        "@babel/proposal-class-properties",
+        "@babel/proposal-object-rest-spread"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm start
 npm run build
 
 # Build your app with minification: 
-npm run build.prod
+npm run build.all
 
 # run unit tests:
 npm run test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "start": "webpack-dev-server --port 9000 --inline --progress --profile --colors --watch --content-base src/ --mode development",
     "build": "webpack --config webpack.config.js --mode production",
     "build.prod": "webpack --config webpack.config.js -p",
+    "build.esnext": "npm run build:types && npm run build:js",
+    "build:types": "tsc --emitDeclarationOnly",
+    "build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
+    "build.all": "npm run build.prod && npm run build.esnext",
     "test": "karma start karma.config.js"
   },
   "keywords": [
@@ -26,11 +30,17 @@
     "karma-phantomjs-launcher": "1.0.4",
     "karma-webpack": "3.0.0",
     "source-map-loader": "0.2.3",
-    "tslint": "5.10.0",
+    "tslint": "5.17.0",
     "tslint-loader": "3.6.0",
-    "typescript": "2.8.3",
+    "typescript": "3.5.1",
     "webpack": "4.12.0",
     "webpack-cli": "3.0.8",
-    "webpack-dev-server": "3.1.4"
+    "webpack-dev-server": "3.1.4",
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.4.0",
+    "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
+    "@babel/preset-env": "^7.4.1",
+    "@babel/preset-typescript": "^7.3.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "target": "es5",
-    "allowJs": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,12 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "target": "es5",
-    "allowJs": true
-  }
+    "allowJs": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
Related to [this feature request](https://github.com/juristr/webpack-typescript-starter/issues/22) I've added a build option that enables `ES-Next` and `typescript` on the `dist` folder so the so the developer will be able to `import` the script and not just inject the code as a script tag.